### PR TITLE
[DO NOT MERGE] Exploring slight changes to APIs

### DIFF
--- a/Sources/Examples/ExampleLoggerImpl.swift
+++ b/Sources/Examples/ExampleLoggerImpl.swift
@@ -123,7 +123,7 @@ public final class ExampleLoggerImplementation: LogHandler {
         }
     }
 
-    public subscript(metadataKey metadataKey: String) -> String? {
+    public subscript(metadataKey metadataKey: LoggingMetadata.Key) -> LoggingMetadata.Value? {
         get {
             return self.lock.withLock { self._metadata[metadataKey] }
         }

--- a/Sources/Examples/ExampleLoggerImpl.swift
+++ b/Sources/Examples/ExampleLoggerImpl.swift
@@ -22,7 +22,7 @@ public struct ExampleValueLoggerImplementation: LogHandler {
     }
 
     public func log(level: LogLevel, message: String, file: String, function: String, line: UInt) {
-        print("\(self.formatLevel(level)): \(message) \(self.metadata?.description ?? "")")
+        print("\(self.formatLevel(level)): \(message) \(self.metadata.description)")
     }
 
     private func formatLevel(_ level: LogLevel) -> String {
@@ -49,16 +49,12 @@ public struct ExampleValueLoggerImplementation: LogHandler {
         }
     }
 
-    public var metadata: LoggingMetadata? {
+    public var metadata: LoggingMetadata {
         get {
             return self._metadata
         }
         set {
-            if let newValue = newValue {
-                self._metadata = newValue
-            } else {
-                self._metadata.removeAll()
-            }
+            self._metadata = newValue
         }
     }
 
@@ -89,6 +85,7 @@ public final class ExampleLoggerImplementation: LogHandler {
         formatter.locale = Locale(identifier: "en_US")
         formatter.calendar = Calendar(identifier: .gregorian)
         self.formatter = formatter
+        self._metadata = LoggingMetadata()
     }
 
     private func formatLevel(_ level: LogLevel) -> String {
@@ -111,13 +108,13 @@ public final class ExampleLoggerImplementation: LogHandler {
     }
 
     private var prettyMetadata: String?
-    private var _metadata: LoggingMetadata? {
+    private var _metadata: LoggingMetadata {
         didSet {
-            self.prettyMetadata = !(self._metadata?.isEmpty ?? true) ? self._metadata!.map { "\($0)=\($1)" }.joined(separator: " ") : nil
+            self.prettyMetadata = !(self._metadata.isEmpty) ? self._metadata.map { "\($0)=\($1)" }.joined(separator: " ") : nil
         }
     }
 
-    public var metadata: LoggingMetadata? {
+    public var metadata: LoggingMetadata {
         get {
             return self.lock.withLock { self._metadata }
         }
@@ -128,14 +125,11 @@ public final class ExampleLoggerImplementation: LogHandler {
 
     public subscript(metadataKey metadataKey: String) -> String? {
         get {
-            return self.lock.withLock { self._metadata?[metadataKey] }
+            return self.lock.withLock { self._metadata[metadataKey] }
         }
         set {
             self.lock.withLock {
-                if nil == self._metadata {
-                    self._metadata = [:]
-                }
-                self._metadata![metadataKey] = newValue
+                self._metadata[metadataKey] = newValue
             }
         }
     }

--- a/Sources/Examples/ExploringPerformanceExample.swift
+++ b/Sources/Examples/ExploringPerformanceExample.swift
@@ -189,6 +189,12 @@ struct ExploringPerformanceExample {
             outerLogger.info("Example logging")
         }
 
+        measureAndPrint(desc: "example") {
+            outerLogger.withMetadata(["hello": "helloooooooo!"]) { scoped in
+                scoped.info("EXAMPLE??????")
+            }
+        }
+
         /*
         [some-id][2018-12-17 05:50:14 +0000][info][only-once=ONLY_1 per-data=some-metadata id=some-id additional=some-per-context-info] Hello
         [some-id][2018-12-17 05:50:14 +0000][info][id=some-id per-data=some-metadata additional=some-per-context-info] Hello Second Time

--- a/Sources/Examples/ExploringPerformanceExample.swift
+++ b/Sources/Examples/ExploringPerformanceExample.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Logging
+
+// MARK: Example library code
+
+struct DataContainer {
+    let data: String // this would be some user `T` type
+
+    // would be W3C's `traceparent` for example
+    let traceContext: TraceContext?
+}
+
+
+// there's a few ways to specify those, this is just an example;
+//
+// See others: https://github.com/opentracing/specification/blob/master/rfc/trace_identifiers.md
+// Though this one is going to be the standardized one soon: https://w3c.github.io/trace-context/
+struct TraceContext {
+    let version: UInt8
+    let traceId: (UInt64, UInt64) // one value in 128 bits
+    let parentId: UInt64
+    let flags: UInt8
+}
+
+extension TraceContext: CustomStringConvertible {
+    public var description: String {
+        let v = String(self.version, radix: 16, uppercase: true)
+        let t1 = String(self.traceId.0, radix: 16, uppercase: true)
+        let t2 = String(self.traceId.1, radix: 16, uppercase: true)
+        let s = String(self.parentId, radix: 16, uppercase: true)
+        let f = String(self.flags, radix: 16, uppercase: true)
+
+        // rendering just an example, did not super closely follow any spec, but close enough:
+        return "\(v)-\(t1)\(t2)-\(s)-\(f)"
+    }
+}
+
+struct SomeContext {
+    let id: String
+    var log: Logger
+}
+
+class Library {
+
+    // somewhere in library, per context
+    // imagine we initialize it safely somewhere, always once,
+    // it has the right context metadata (e.g. the above id), which remains the same for the lifetime of this context
+    // but also we need to set things on it per invocation
+    private var log: Logger
+
+    // pseudo structure
+    private var context: SomeContext
+
+    init() {
+        let id = "some-id"
+        // assume we know the context id here:
+        var log = Logging.make(id)
+        log.metadata = ["id": "\(id)"]
+        log.metadata["additional"] = "some-per-context-info" // could require "rendering into a string"
+
+        self.log = log
+
+        let context: SomeContext = SomeContext(id: id, log: self.log)
+        self.context = context
+    }
+
+    private func extractMeta(from envelope: DataContainer, withBase metadata: LoggingMetadata) -> LoggingMetadata {
+        var renderedMetadata: LoggingMetadata = [:]
+
+        switch envelope.traceContext {
+        case .some(let trace):
+            renderedMetadata = [
+                "per-data0": "some-metadata",
+                // TODO: So that's the thing I'm a bit worried about with the string metadata:
+                // TODO: this rendering is a bit costly, though we'd likely want to carry around the integers rather than the string repr...
+                // TODO: Sadly with String metadata we always have to render it, even if we don't even log here AT ALL :-(
+                // TODO: solution 1) pass around the trace metadata as String all the time in the envelope, this
+                // TODO: solution 2) "whatever", yeah it costs
+                "trace": "\(trace)"
+            ]
+        case .none:
+            renderedMetadata = [
+                "per-data0": "some-metadata",
+            ]
+
+        }
+
+        return renderedMetadata
+    }
+
+    func handle(userCallback: (inout SomeContext, DataContainer) -> ()) {
+        let perContextMetadata: LoggingMetadata = context.log.metadata
+
+        let trace = TraceContext(// assume we have it, it came with the envelope
+            version: 0,
+            traceId: (790211418057950173, 9532127138774266268),
+            parentId: 67667974448284343,
+            flags: 0
+        )
+        let data = DataContainer(data: "example", traceContext: trace)
+
+        // TODO: forced into rendering the internal trace representations from ints to string repr
+        let moreMetadata = extractMeta(from: data, withBase: perContextMetadata)
+
+        var allMetadata: LoggingMetadata = perContextMetadata
+        allMetadata.merge(moreMetadata, uniquingKeysWith: { (l, r) in r })
+
+        context.log.metadata = allMetadata
+        defer {
+            context.log.metadata = perContextMetadata
+        }
+        userCallback(&context, data)
+    }
+}
+
+struct ExploringPerformanceExample {
+
+
+    func main() {
+        let outerLogger = Logging.make("other")
+
+        let library = Library()
+
+        measureAndPrint(desc: "set one metadata") {
+            library.handle {
+                context, data in
+                context.log.metadata["only-once"] = "ONLY_1"
+                context.log.info("Hello")
+            }
+
+        }
+
+        measureAndPrint(desc: "set 10 metadata") {
+            library.handle { context, data in
+                context.log.metadata["only-1"] = "ONLY"
+                context.log.metadata["only-2"] = "ONLY"
+                context.log.metadata["only-3"] = "ONLY"
+                context.log.metadata["only-4"] = "ONLY"
+                context.log.metadata["only-5"] = "ONLY"
+                context.log.metadata["only-6"] = "ONLY"
+                context.log.metadata["only-7"] = "ONLY"
+                context.log.metadata["only-8"] = "ONLY"
+                context.log.metadata["only-9"] = "ONLY"
+                context.log.metadata["only-10"] = "ONLY"
+                context.log.info("Hello")
+            }
+        }
+
+        let traceExample = TraceContext(
+            version: 0,
+            traceId: (790211418057950173, 9532127138774266268),
+            parentId: 67667974448284343,
+            flags: 0
+        )
+        measureAndPrint(desc: "rendering traces") {
+            let rendered = "\(traceExample)"
+            print("rendered: \(rendered)")
+        }
+
+        measureAndPrint(desc: "only context metadata, no additional") {
+            library.handle { context, data in
+                // should not have the [exactly-once] logged
+                context.log.info("Hello Second Time")
+            }
+        }
+
+        measureAndPrint(desc: "user callback not logging at all") {
+            library.handle { context, data in
+                return () // no logging == should be no cost of rendering reprs
+            }
+        }
+
+        measureAndPrint(desc: "override context value") {
+            library.handle { context, data in
+                // overrides value of "additional" for only this log statement
+                context.log.metadata["additional"] = "OVERRIDDEN"
+                context.log.info("Hello Second Time")
+            }
+        }
+
+        measureAndPrint(desc: "100 logs") {
+            for item in 0...100 {
+                library.handle { context, data in
+                    context.log.info("Hello \(item)")
+                }
+            }
+        }
+        measureAndPrint(desc: "no 10000 logs") {
+            for _ in 0...100 {
+                library.handle { context, data in
+                    ()
+                }
+            }
+        }
+
+        measureAndPrint(desc: "no context") {
+            outerLogger.info("Example logging")
+        }
+
+        /*
+        [some-id][2018-12-17 05:50:14 +0000][info][only-once=ONLY_1 per-data=some-metadata id=some-id additional=some-per-context-info] Hello
+        [some-id][2018-12-17 05:50:14 +0000][info][id=some-id per-data=some-metadata additional=some-per-context-info] Hello Second Time
+        [some-id][2018-12-17 05:50:14 +0000][info][id=some-id per-data=some-metadata additional=OVERRIDDEN] Hello Second Time
+        [other][2018-12-17 05:50:14 +0000][info][] Example logging
+        [other][2018-12-17 05:50:14 +0000][info][] Example logging
+        */
+    }
+
+}

--- a/Sources/Examples/PoorMansBenchmarking.swift
+++ b/Sources/Examples/PoorMansBenchmarking.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Logging
+
+/// Copied from NIO
+public struct TimeAmount {
+
+    #if arch(arm) || arch(i386)
+    // Int64 is the correct type here but we don't want to break SemVer so can't change it for the 64-bit platforms.
+    // To be fixed in NIO 2.0
+    public typealias Value = Int64
+    #else
+    // 64-bit, keeping that at Int for SemVer in the 1.x line.
+    public typealias Value = Int
+    #endif
+
+    /// The nanoseconds representation of the `TimeAmount`.
+    public let nanoseconds: Value
+
+    private init(_ nanoseconds: Value) {
+        self.nanoseconds = nanoseconds
+    }
+
+    /// Creates a new `TimeAmount` for the given amount of nanoseconds.
+    ///
+    /// - parameters:
+    ///     - amount: the amount of nanoseconds this `TimeAmount` represents.
+    /// - returns: the `TimeAmount` for the given amount.
+    public static func nanoseconds(_ amount: Value) -> TimeAmount {
+        return TimeAmount(amount)
+    }
+
+    /// Creates a new `TimeAmount` for the given amount of microseconds.
+    ///
+    /// - parameters:
+    ///     - amount: the amount of microseconds this `TimeAmount` represents.
+    /// - returns: the `TimeAmount` for the given amount.
+    public static func microseconds(_ amount: Value) -> TimeAmount {
+        return TimeAmount(amount * 1000)
+    }
+
+    /// Creates a new `TimeAmount` for the given amount of milliseconds.
+    ///
+    /// - parameters:
+    ///     - amount: the amount of milliseconds this `TimeAmount` represents.
+    /// - returns: the `TimeAmount` for the given amount.
+    public static func milliseconds(_ amount: Value) -> TimeAmount {
+        return TimeAmount(amount * 1000 * 1000)
+    }
+
+    /// Creates a new `TimeAmount` for the given amount of seconds.
+    ///
+    /// - parameters:
+    ///     - amount: the amount of seconds this `TimeAmount` represents.
+    /// - returns: the `TimeAmount` for the given amount.
+    public static func seconds(_ amount: Value) -> TimeAmount {
+        return TimeAmount(amount * 1000 * 1000 * 1000)
+    }
+
+    /// Creates a new `TimeAmount` for the given amount of minutes.
+    ///
+    /// - parameters:
+    ///     - amount: the amount of minutes this `TimeAmount` represents.
+    /// - returns: the `TimeAmount` for the given amount.
+    public static func minutes(_ amount: Value) -> TimeAmount {
+        return TimeAmount(amount * 1000 * 1000 * 1000 * 60)
+    }
+
+    /// Creates a new `TimeAmount` for the given amount of hours.
+    ///
+    /// - parameters:
+    ///     - amount: the amount of hours this `TimeAmount` represents.
+    /// - returns: the `TimeAmount` for the given amount.
+    public static func hours(_ amount: Value) -> TimeAmount {
+        return TimeAmount(amount * 1000 * 1000 * 1000 * 60 * 60)
+    }
+}
+
+/// "Pretty" time amount rendering, useful for human readable durations in tests
+extension TimeAmount {
+    // TODO build our own rather than extending the NIO one
+
+    public var prettyDescription: String {
+        return self.prettyDescription()
+    }
+
+    public func prettyDescription(precision: Int = 2) -> String {
+        assert(precision > 0, "precision MUST BE > 0")
+        var res = ""
+
+        var remaining = self
+        var i = 0
+        while i < precision {
+            let unit = chooseUnit(remaining.nanoseconds)
+
+            let rounded: Int = remaining.nanoseconds / unit.rawValue
+            if rounded > 0 {
+                res += i > 0 ? " " : ""
+                res += "\(rounded)\(unit.abbreviated)"
+
+                remaining = TimeAmount.nanoseconds(remaining.nanoseconds - unit.timeAmount(rounded).nanoseconds)
+                i += 1
+            } else {
+                break
+            }
+        }
+
+        return res
+    }
+
+    private func chooseUnit(_ ns: Value) -> TimeUnit {
+        //@formatter:off
+        if ns / TimeUnit.days.rawValue > 0 {
+            return TimeUnit.days
+        } else if ns / TimeUnit.hours.rawValue > 0 {
+            return TimeUnit.hours
+        } else if ns / TimeUnit.minutes.rawValue > 0 {
+            return TimeUnit.minutes
+        } else if ns / TimeUnit.seconds.rawValue > 0 {
+            return TimeUnit.seconds
+        } else if ns / TimeUnit.milliseconds.rawValue > 0 {
+            return TimeUnit.milliseconds
+        } else if ns / TimeUnit.microseconds.rawValue > 0 {
+            return TimeUnit.microseconds
+        } else {
+            return TimeUnit.nanoseconds
+        }
+        //@formatter:on
+    }
+
+    /// Represents number of nanoseconds within given time unit
+    enum TimeUnit: Value {
+        //@formatter:off
+        case days = 86_400_000_000_000
+        case hours = 3_600_000_000_000
+        case minutes = 60_000_000_000
+        case seconds = 1_000_000_000
+        case milliseconds = 1_000_000
+        case microseconds = 1_000
+        case nanoseconds = 1
+        //@formatter:on
+
+        var abbreviated: String {
+            switch self {
+            case .nanoseconds: return "ns"
+            case .microseconds: return "μs"
+            case .milliseconds: return "ms"
+            case .seconds: return "s"
+            case .minutes: return "m"
+            case .hours: return "h"
+            case .days: return "d"
+            }
+        }
+
+        func timeAmount(_ amount: Int) -> TimeAmount {
+            switch self {
+            case .nanoseconds: return .nanoseconds(amount)
+            case .microseconds: return .microseconds(amount)
+            case .milliseconds: return .milliseconds(amount)
+            case .seconds: return .seconds(amount)
+            case .minutes: return .minutes(amount)
+            case .hours: return .hours(amount)
+            case .days: return .hours(amount * 24)
+            }
+        }
+
+    }
+}
+
+////// toy benchmark infra
+
+public func measure(_ fn: () throws -> Void) rethrows -> [TimeInterval] {
+    func measureOne(_ fn: () throws -> Void) rethrows -> TimeInterval {
+        let start = Date()
+        _ = try fn()
+        let end = Date()
+        return end.timeIntervalSince(start)
+    }
+
+    _ = try measureOne(fn) /* pre-heat and throw away */
+    var measurements = Array(repeating: 0.0, count: 10)
+    for i in 0..<10 {
+        measurements[i] = try measureOne(fn)
+    }
+    return measurements
+}
+
+public func measureAndPrint(desc: String, fn: () throws -> Void) rethrows -> Void {
+    print("measuring: \(desc): ")
+    let measurements = try measure(fn)
+
+    print(measurements.reduce("") { (acc, m: TimeInterval) in
+        let prettyMeasurement = TimeAmount.nanoseconds(TimeAmount.Value(m * 1_000_000_000))
+        return acc + "\(prettyMeasurement.prettyDescription), "
+    })
+}
+
+////// end of toy benchmark infra

--- a/Sources/Examples/main.swift
+++ b/Sources/Examples/main.swift
@@ -1,14 +1,16 @@
-print("##### explicit logger passing #####")
-ExplicitContextPassingExample.main()
+//print("##### explicit logger passing #####")
+//ExplicitContextPassingExample.main()
+//
+//print()
+//print("##### one global logger #####")
+//OneGlobalLoggerExample.main()
+//
+//print()
+//print("##### logger per sub-system #####")
+//LoggerPerSubsystemExample.main()
+//
+//print()
+//print("##### other random examples #####")
+//RandomExample.main()
 
-print()
-print("##### one global logger #####")
-OneGlobalLoggerExample.main()
-
-print()
-print("##### logger per sub-system #####")
-LoggerPerSubsystemExample.main()
-
-print()
-print("##### other random examples #####")
-RandomExample.main()
+ExploringPerformanceExample().main()

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -62,7 +62,7 @@ public struct Logger {
     }
 
     @inlinable
-    public subscript(metadataKey metadataKey: String) -> String? {
+    public subscript(metadataKey metadataKey: LoggingMetadata.Key) -> LoggingMetadata.Value? {
         get {
             return self.handler[metadataKey: metadataKey]
         }
@@ -100,32 +100,28 @@ public enum LogLevel: Int {
     case error
 }
 
-// logging with String value
-//    [some-id][2018-12-17 10:26:41 +0000][info][id=some-id trace=0-AF7651916CD43DD8448EB211C80319C-F067AA0BA902B7-0 per-data0=some-metadata additional=some-per-context-info] Hello 100
+// logging with String value, "before"
+//    measuring: 100 logs:
+//    // [some-id][2018-12-17 10:26:41 +0000][info][id=some-id trace=0-AF7651916CD43DD8448EB211C80319C-F067AA0BA902B7-0 per-data0=some-metadata additional=some-per-context-info] Hello 100
 //    7ms 655μs, 7ms 50μs, 6ms 155μs, 5ms 825μs, 21ms 72μs, 6ms 314μs, 6ms 96μs, 10ms 315μs, 5ms 653μs, 7ms 46μs,
 //    measuring: no 100 logs:
 //    1ms 223μs, 1ms 295μs, 1ms 260μs, 1ms 340μs, 1ms 386μs, 1ms 419μs, 1ms 525μs, 1ms 476μs, 1ms 482μs, 1ms 608μs,
 //
 // String:String, with didSet rendering
-//    2018-12-17 11:35:49 +0000 infoid=some-id additional=some-per-context-info per-data0=some-metadata trace=0-AF7651916CD43DD8448EB211C80319C-F067AA0BA902B7-0 Hello 100
+//    measuring: 100 logs:
+//    // 2018-12-17 11:35:49 +0000 id=some-id additional=some-per-context-info per-data0=some-metadata trace=0-AF7651916CD43DD8448EB211C80319C-F067AA0BA902B7-0 Hello 100
 //    10ms 915μs, 6ms 531μs, 6ms 68μs, 5ms 735μs, 5ms 870μs, 9ms 493μs, 6ms 564μs, 7ms 400μs, 10ms 455μs, 7ms 205μs,
 //    measuring: no 10000 logs:
 //    1ms 643μs, 1ms 592μs, 1ms 671μs, 1ms 579μs, 1ms 602μs, 1ms 565μs, 1ms 560μs, 1ms 539μs, 1ms 510μs, 1ms 499μs,
 //
-// String:Any, logging with lazy Any rendering on actual logging
-//    [some-id][2018-12-17 10:37:53 +0000][info][per-data0=some-metadata id=some-id trace=0-AF7651916CD43DD8448EB211C80319C-F067AA0BA902B7-0 additional=some-per-context-info] Hello 100
-//    7ms 645μs, 7ms 209μs, 6ms 759μs, 15ms 522μs, 7ms 45μs, 6ms 743μs, 12ms 90μs, 7ms 779μs, 7ms 417μs, 6ms 832μs,
-//    ^~~~~~~ no change here is good and expected, seems the Any does not hurt as much, and we allow not paying the cost:
-//    measuring: no 10000 logs:
-//    543μs 951ns, 543μs 951ns, 548μs 958ns, 527μs 24ns, 590μs 85ns, 510μs 931ns, 512μs 3ns, 511μs 50ns, 509μs 977ns, 522μs 971ns,
-//    ^~~~~~ compared to at least always above 1ms times for when we don't actually render any logs (e.g. because log level)
-//
 // String:Any, avoiding didSet, rendering only when actually printing
-//    20ms 616μs, 7ms 309μs, 6ms 725μs, 11ms 933μs, 6ms 517μs, 6ms 186μs, 5ms 877μs, 10ms 561μs, 7ms 166μs, 6ms 537μs,
+//    measuring: 100 logs:
+//    // [2018-12-17 12:04:45 +0000][info][additional=some-per-context-info trace=0-AF7651916CD43DD8448EB211C80319C-F067AA0BA902B7-0 per-data0=some-metadata id=some-id] Hello 100
+//    20ms 89μs, 6ms 877μs, 8ms 257μs, 10ms 628μs, 6ms 299μs, 5ms 718μs, 5ms 723μs, 5ms 362μs, 8ms 759μs, 6ms 155μs,
 //    measuring: no 10000 logs:
-//    699μs 43ns, 699μs 996ns, 645μs 41ns, 668μs 48ns, 698μs 924ns, 789μs 999ns, 648μs 21ns, 604μs 33ns, 633μs 1ns, 751μs 972ns,
-// public typealias LoggingMetadata = [String: Any]
-public typealias LoggingMetadata = [String: String]
+//    675μs 82ns, 394μs 940ns, 393μs 986ns, 393μs 986ns, 393μs 986ns, 394μs 940ns, 395μs 59ns, 394μs 940ns, 395μs 59ns, 486μs 16ns,
+public typealias LoggingMetadata = [String: Any]
+// public typealias LoggingMetadata = [String: String]
 
 extension LogLevel: Comparable {
     public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
@@ -175,16 +171,11 @@ public final class StdoutLogger: LogHandler {
         }
     }
 
-    private var prettyMetadata: String = ""
-    private var _metadata: LoggingMetadata {
-        didSet {
-            self.prettyMetadata = !(self._metadata.isEmpty) ? self._metadata.map { "\($0)=\($1)" }.joined(separator: " ") : ""
-        }
-    }
-
+    private var _metadata: LoggingMetadata
     public func log(level: LogLevel, message: String, file _: String, function _: String, line _: UInt) {
         if level >= self.logLevel {
-            print("\(Date()) \(level)\(self.prettyMetadata) \(message)")
+            let prettyMetadata = !(self._metadata.isEmpty) ? self._metadata.map { "\($0)=\($1)" }.joined(separator: " ") : ""
+            print("[\(Date())][\(level)][\(prettyMetadata)] \(message)")
         }
     }
 
@@ -197,7 +188,7 @@ public final class StdoutLogger: LogHandler {
         }
     }
 
-    public subscript(metadataKey metadataKey: String) -> String? {
+    public subscript(metadataKey metadataKey: LoggingMetadata.Key) -> LoggingMetadata.Value? {
         get {
             return self.lock.withLock { self._metadata[metadataKey] }
         }

--- a/Tests/LoggingTests/MDCTest.swift
+++ b/Tests/LoggingTests/MDCTest.swift
@@ -21,7 +21,7 @@ class MDCTest: XCTestCase {
                 for i in 0 ... remove {
                     MDC.global["key-\(i)"] = nil
                 }
-                XCTAssertEqual(add - remove, MDC.global.metadata?.count ?? 0, "expected number of entries to match")
+                XCTAssertEqual(add - remove, MDC.global.metadata.count, "expected number of entries to match")
                 for i in remove + 1 ... add {
                     XCTAssertNotNil(MDC.global["key-\(i)"], "expecting value for key-\(i)")
                 }
@@ -35,6 +35,6 @@ class MDCTest: XCTestCase {
         group.wait()
         XCTAssertEqual(MDC.global["foo"], "bar", "expecting to find top items")
         MDC.global["foo"] = nil
-        XCTAssertTrue(MDC.global.metadata?.isEmpty ?? true, "MDC should be empty")
+        XCTAssertTrue(MDC.global.metadata.isEmpty, "MDC should be empty")
     }
 }


### PR DESCRIPTION
Not intended for merging but showcasing rationale for "decide type for metadata value #5" as well as  some minor refactor proposals for the api:

- potentially change `public var metadata: LoggingMetadata? {` to `public var metadata: LoggingMetadata {` to avoid nil compensation code everywhere
- avoid "eager rendering" of values which need to compute their string representations by:
  - avoid `String` value type in the Metadata dictionary
  - avoid `didSet` and storing (pre)rendered prettyMetadata since it forces eagerly rendering the values, even if logging does not happen with current metadata
  - only render metadata when indeed logging values

This PR is not intended to be merged as is, but only to show the main idea behind a change.
If we agree on the changes I can make a clean PR or if you'd rather apply changes we'd agree on yourself I'm find with that happening independently as well.

To run the example and observe measurements (not super advanced, but hey, it's something):

`swift run Examples --configuration release`