### PR TITLE
add multiplex logger

### DIFF
--- a/Sources/Examples/ExampleLoggerImpl.swift
+++ b/Sources/Examples/ExampleLoggerImpl.swift
@@ -18,10 +18,9 @@ private extension NSLock {
 public struct ExampleValueLoggerImplementation: LogHandler {
     private var _metadata: LoggingMetadata = [:]
 
-    public init(label: String) {
-    }
+    public init(label _: String) {}
 
-    public func log(level: LogLevel, message: String, file: String, function: String, line: UInt) {
+    public func log(level: LogLevel, message: String, file _: String, function _: String, line _: UInt) {
         print("\(self.formatLevel(level)): \(message) \(self.metadata?.description ?? "")")
     }
 

--- a/Sources/Examples/MUXExample.swift
+++ b/Sources/Examples/MUXExample.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Logging
+
+enum MUXExample {
+    static func main() {
+        // boostrap with logging that multiplexes to two copies of ExampleLoggerImplementation
+        Logging.bootstrap(MultiplexLogging([ExampleLoggerImplementation.init, ExampleLoggerImplementation.init]).make)
+
+        let logger = Logging.make("com.example.TestApp")
+        logger.info("we should see this twice!")
+    }
+}

--- a/Sources/Examples/main.swift
+++ b/Sources/Examples/main.swift
@@ -12,3 +12,7 @@ LoggerPerSubsystemExample.main()
 print()
 print("##### other random examples #####")
 RandomExample.main()
+
+print()
+print("##### mux examples #####")
+MUXExample.main()

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -1,0 +1,21 @@
+@testable import Logging
+import XCTest
+
+class LoggingTest: XCTestCase {
+    func testMUX() throws {
+        // bootstrap with our test logging impl
+        let logging1 = TestLogging()
+        let logging2 = TestLogging()
+        Logging.bootstrap(MultiplexLogging([logging1.make, logging2.make]).make)
+
+        var logger = Logging.make("test")
+        logger.logLevel = .warn
+        logger.info("hello world")
+        logger[metadataKey: "foo"] = "bar"
+        logger.warn("hello world!")
+        logging1.history.assertNotExist(level: .info, metadata: nil, message: "hello world")
+        logging2.history.assertNotExist(level: .info, metadata: nil, message: "hello world")
+        logging1.history.assertExist(level: .warn, metadata: ["foo": "bar"], message: "hello world!")
+        logging2.history.assertExist(level: .warn, metadata: ["foo": "bar"], message: "hello world!")
+    }
+}


### PR DESCRIPTION
motivation: support situations when users want to multiplex to multiple logging implementations

changes:
* add MultiplexLogging (factory) and MUXLogHandler (implementation), allowing user to plug in multiple logging implementations
* add tests and examples to demonstrate the functionality