### PR TITLE
make logger metadata non-optional

### DIFF
--- a/Sources/ExampleImplementation/ConfigLogging.swift
+++ b/Sources/ExampleImplementation/ConfigLogging.swift
@@ -37,7 +37,7 @@ public final class ConfigLogging {
             set { self.logger.logLevel = newValue }
         }
 
-        public var metadata: Logging.Metadata? {
+        public var metadata: Logging.Metadata {
             get { return self.logger.metadata }
             set { self.logger.metadata = newValue }
         }

--- a/Sources/ExampleImplementation/FileLogging.swift
+++ b/Sources/ExampleImplementation/FileLogging.swift
@@ -43,7 +43,7 @@ public final class FileLogging {
             set { self.logger.logLevel = newValue }
         }
 
-        public var metadata: Logging.Metadata? {
+        public var metadata: Logging.Metadata {
             get { return self.logger.metadata }
             set { self.logger.metadata = newValue }
         }

--- a/Sources/ExampleImplementation/SimpleLogger.swift
+++ b/Sources/ExampleImplementation/SimpleLogger.swift
@@ -37,13 +37,13 @@ internal final class SimpleLogger {
     }
 
     private var prettyMetadata: String?
-    private var _metadata: Logging.Metadata? {
+    private var _metadata = Logging.Metadata() {
         didSet {
-            self.prettyMetadata = !(self._metadata?.isEmpty ?? true) ? self._metadata!.map { "\($0)=\($1)" }.joined(separator: " ") : nil
+            self.prettyMetadata = !self._metadata.isEmpty ? self._metadata.map { "\($0)=\($1)" }.joined(separator: " ") : nil
         }
     }
 
-    public var metadata: Logging.Metadata? {
+    public var metadata: Logging.Metadata {
         get {
             return self.lock.withLock { self._metadata }
         }
@@ -54,14 +54,11 @@ internal final class SimpleLogger {
 
     public subscript(metadataKey metadataKey: String) -> Logging.Metadata.Value? {
         get {
-            return self.lock.withLock { self._metadata?[metadataKey] }
+            return self.lock.withLock { self._metadata[metadataKey] }
         }
         set {
             self.lock.withLock {
-                if nil == self._metadata {
-                    self._metadata = [:]
-                }
-                self._metadata![metadataKey] = newValue
+                self._metadata[metadataKey] = newValue
             }
         }
     }

--- a/Sources/ExampleImplementation/SimpleLogging.swift
+++ b/Sources/ExampleImplementation/SimpleLogging.swift
@@ -35,7 +35,7 @@ public final class SimpleLogging {
             set { self.logger.logLevel = newValue }
         }
 
-        public var metadata: Logging.Metadata? {
+        public var metadata: Logging.Metadata {
             get { return self.logger.metadata }
             set { self.logger.metadata = newValue }
         }

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -17,7 +17,7 @@ public protocol LogHandler {
     subscript(metadataKey _: String) -> Logging.Metadata.Value? { get set }
 
     // All available metatdata
-    var metadata: Logging.Metadata? { get set }
+    var metadata: Logging.Metadata { get set }
 
     // The log level
     var logLevel: Logging.Level { get set }
@@ -76,7 +76,7 @@ public struct Logger {
     }
 
     @inlinable
-    public var metadata: Logging.Metadata? {
+    public var metadata: Logging.Metadata {
         get {
             return self.handler.metadata
         }
@@ -205,7 +205,7 @@ private class MUXLogHandler: LogHandler {
         }
     }
 
-    public var metadata: Logging.Metadata? {
+    public var metadata: Logging.Metadata {
         get {
             return self.handlers[0].metadata
         }
@@ -216,7 +216,7 @@ private class MUXLogHandler: LogHandler {
 
     public subscript(metadataKey metadataKey: String) -> Logging.Metadata.Value? {
         get {
-            return self.handlers[0].metadata?[metadataKey]
+            return self.handlers[0].metadata[metadataKey]
         }
         set {
             self.mutateHandlers { $0[metadataKey: metadataKey] = newValue }
@@ -253,9 +253,9 @@ internal final class StdoutLogger: LogHandler {
     }
 
     private var prettyMetadata: String?
-    private var _metadata: Logging.Metadata? {
+    private var _metadata = Logging.Metadata() {
         didSet {
-            self.prettyMetadata = !(self._metadata?.isEmpty ?? true) ? self._metadata!.map { "\($0)=\($1)" }.joined(separator: " ") : nil
+            self.prettyMetadata = !self._metadata.isEmpty ? self._metadata.map { "\($0)=\($1)" }.joined(separator: " ") : nil
         }
     }
 
@@ -265,7 +265,7 @@ internal final class StdoutLogger: LogHandler {
         }
     }
 
-    public var metadata: Logging.Metadata? {
+    public var metadata: Logging.Metadata {
         get {
             return self.lock.withLock { self._metadata }
         }
@@ -276,14 +276,11 @@ internal final class StdoutLogger: LogHandler {
 
     public subscript(metadataKey metadataKey: String) -> Logging.Metadata.Value? {
         get {
-            return self.lock.withLock { self._metadata?[metadataKey] }
+            return self.lock.withLock { self._metadata[metadataKey] }
         }
         set {
             self.lock.withLock {
-                if nil == self._metadata {
-                    self._metadata = [:]
-                }
-                self._metadata![metadataKey] = newValue
+                self._metadata[metadataKey] = newValue
             }
         }
     }

--- a/Tests/LoggingTests/MDCTest.swift
+++ b/Tests/LoggingTests/MDCTest.swift
@@ -21,7 +21,7 @@ class MDCTest: XCTestCase {
                 for i in 0 ... remove {
                     MDC.global["key-\(i)"] = nil
                 }
-                XCTAssertEqual(add - remove, MDC.global.metadata?.count ?? 0, "expected number of entries to match")
+                XCTAssertEqual(add - remove, MDC.global.metadata.count, "expected number of entries to match")
                 for i in remove + 1 ... add {
                     XCTAssertNotNil(MDC.global["key-\(i)"], "expecting value for key-\(i)")
                 }
@@ -35,6 +35,6 @@ class MDCTest: XCTestCase {
         group.wait()
         XCTAssertEqual(MDC.global["foo"], "bar", "expecting to find top items")
         MDC.global["foo"] = nil
-        XCTAssertTrue(MDC.global.metadata?.isEmpty ?? true, "MDC should be empty")
+        XCTAssertTrue(MDC.global.metadata.isEmpty, "MDC should be empty")
     }
 }


### PR DESCRIPTION
motivation: simpler / cleaner API

changes: change logger Metadata API to be non-nullable, since the original motivation is no longer valid