### PR TITLE
add support for local metadata (option 1)

### DIFF
--- a/Sources/ExampleImplementation/ConfigLogging.swift
+++ b/Sources/ExampleImplementation/ConfigLogging.swift
@@ -26,8 +26,8 @@ public final class ConfigLogging {
             self.config = config
         }
 
-        public func log(level: Logging.Level, message: String, error: Error?, file: StaticString, function: StaticString, line: UInt) {
-            self.logger.log(level: level, message: message, error: error) { text in
+        public func log(level: Logging.Level, message: String, metadata: Logging.Metadata?, error: Error?, file: StaticString, function: StaticString, line: UInt) {
+            self.logger.log(level: level, message: message, metadata: metadata, error: error) { text in
                 print(text)
             }
         }

--- a/Sources/ExampleImplementation/FileLogging.swift
+++ b/Sources/ExampleImplementation/FileLogging.swift
@@ -32,8 +32,8 @@ public final class FileLogging {
             self.fileHandler = fileHandler
         }
 
-        public func log(level: Logging.Level, message: String, error: Error?, file: StaticString, function: StaticString, line: UInt) {
-            self.logger.log(level: level, message: message, error: error) { text in
+        public func log(level: Logging.Level, message: String, metadata: Logging.Metadata?, error: Error?, file: StaticString, function: StaticString, line: UInt) {
+            self.logger.log(level: level, message: message, metadata: metadata, error: error) { text in
                 self.fileHandler._write(text)
             }
         }

--- a/Sources/ExampleImplementation/SimpleLogger.swift
+++ b/Sources/ExampleImplementation/SimpleLogger.swift
@@ -21,8 +21,9 @@ internal final class SimpleLogger {
         self.formatter = formatter
     }
 
-    public func log(level: Logging.Level, message: String, error: Error?, printer: (String) -> Void) {
-        printer("[\(self.label)] \(self.formatter.string(from: Date()))\(self.prettyMetadata.map { " \($0)" } ?? "") \(level): \(message)\(error.map { " \($0)" } ?? "")")
+    public func log(level: Logging.Level, message: String, metadata: Logging.Metadata?, error: Error?, printer: (String) -> Void) {
+        let prettyMetadata = metadata?.isEmpty ?? true ? self.prettyMetadata : self.prettify(self.metadata.merging(metadata!, uniquingKeysWith: { _, new in new }))
+        printer("[\(self.label)] \(self.formatter.string(from: Date()))\(prettyMetadata.map { " \($0)" } ?? "") \(level): \(message)\(error.map { " \($0)" } ?? "")")
     }
 
     public var logLevel: Logging.Level? {
@@ -39,7 +40,7 @@ internal final class SimpleLogger {
     private var prettyMetadata: String?
     private var _metadata = Logging.Metadata() {
         didSet {
-            self.prettyMetadata = !self._metadata.isEmpty ? self._metadata.map { "\($0)=\($1)" }.joined(separator: " ") : nil
+            self.prettyMetadata = self.prettify(self._metadata)
         }
     }
 
@@ -61,6 +62,10 @@ internal final class SimpleLogger {
                 self._metadata[metadataKey] = newValue
             }
         }
+    }
+
+    private func prettify(_ metadata: Logging.Metadata) -> String? {
+        return !metadata.isEmpty ? metadata.map { "\($0)=\($1)" }.joined(separator: " ") : nil
     }
 }
 

--- a/Sources/ExampleImplementation/SimpleLogging.swift
+++ b/Sources/ExampleImplementation/SimpleLogging.swift
@@ -24,8 +24,8 @@ public final class SimpleLogging {
             self.defaultLogLevel = defaultLogLevel
         }
 
-        public func log(level: Logging.Level, message: String, error: Error?, file: StaticString, function: StaticString, line: UInt) {
-            self.logger.log(level: level, message: message, error: error) { text in
+        public func log(level: Logging.Level, message: String, metadata: Logging.Metadata?, error: Error?, file: StaticString, function: StaticString, line: UInt) {
+            self.logger.log(level: level, message: message, metadata: metadata, error: error) { text in
                 print(text)
             }
         }

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -152,10 +152,24 @@ class LoggingTest: XCTestCase {
         logger.logLevel = .error
         logger[metadataKey: "foo"] = .lazy({ "\(self.dontEvaluateThisString())" })
 
-        logger.debug(self.dontEvaluateThisString())
+        logger.debug(self.dontEvaluateThisString(), metadata: ["foo": "\(self.dontEvaluateThisString())"])
         logger.trace(self.dontEvaluateThisString())
         logger.info(self.dontEvaluateThisString())
         logger.warning(self.dontEvaluateThisString())
         logger.log(level: .warning, message: self.dontEvaluateThisString())
+    }
+
+    func testLocalMetadata() {
+        let testLogging = TestLogging()
+        Logging.bootstrap(testLogging.make)
+        var logger = Logging.make("\(#function)")
+        logger.info("hello world!", metadata: ["foo": "bar"])
+        logger[metadataKey: "bar"] = "baz"
+        logger[metadataKey: "baz"] = "qux"
+        logger.warning("hello world!")
+        logger.error("hello world!", metadata: ["baz": "quc"])
+        testLogging.history.assertExist(level: .info, message: "hello world!", metadata: ["foo": "bar"])
+        testLogging.history.assertExist(level: .warning, message: "hello world!", metadata: ["bar": "baz", "baz": "qux"])
+        testLogging.history.assertExist(level: .error, message: "hello world!", metadata: ["bar": "baz", "baz": "quc"])
     }
 }

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -30,15 +30,11 @@ internal struct TestLogger: LogHandler {
         self.logger.logLevel = .trace
     }
 
-    func log(level: Logging.Level, message: String, error: Error?, file: StaticString, function: StaticString, line: UInt) {
-        let metadata = self._metadataSet ? self.metadata : MDC.global.metadata // use MDC unless set
+    func log(level: Logging.Level, message: String, metadata: Logging.Metadata?, error: Error?, file: StaticString, function: StaticString, line: UInt) {
+        let metadata = (self._metadataSet ? self.metadata : MDC.global.metadata).merging(metadata ?? [:], uniquingKeysWith: { _, new in new })
         var l = logger // local copy since we gonna override its metadata
         l.metadata = metadata
-        if let e = error {
-            l.log(level: level, message: message, error: e, file: file, function: function, line: line)
-        } else {
-            l.log(level: level, message: message, file: file, function: function, line: line)
-        }
+        l.log(level: level, message: message, metadata: metadata, error: error, file: file, function: function, line: line)
         self.recorder.record(level: level, metadata: metadata, message: message, error: error)
     }
 


### PR DESCRIPTION
motivation: allow users to define metadata at the log API call site

changes: add metadata param to all log APIs, and implement merge at our example implementations