### PR TITLE
remove Metadata.Value.lazy

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -121,7 +121,6 @@ extension Logging {
         case string(String)
         indirect case dictionary(Metadata)
         indirect case list([Metadata.Value])
-        indirect case lazy (() -> Metadata.Value)
     }
 
     public enum Level: Int {
@@ -139,34 +138,7 @@ extension Logging.Level: Comparable {
     }
 }
 
-extension Logging.Metadata.Value: Equatable {
-    public static func == (lhs: Logging.MetadataValue, rhs: Logging.MetadataValue) -> Bool {
-        switch (lhs, rhs) {
-        case (.string(let lhs), .string(let rhs)):
-            return lhs == rhs
-        case (.list(let lhs), .list(let rhs)):
-            return lhs == rhs
-        case (.dictionary(let lhs), .dictionary(let rhs)):
-            return lhs == rhs
-        case (.lazy(let lhs), .lazy(let rhs)):
-            return lhs() == rhs()
-        case (.lazy(let lhs), .string(let rhs)):
-            return lhs() == .string(rhs)
-        case (.lazy(let lhs), .dictionary(let rhs)):
-            return lhs() == .dictionary(rhs)
-        case (.lazy(let lhs), .list(let rhs)):
-            return lhs() == .list(rhs)
-        case (.dictionary(let lhs), .lazy(let rhs)):
-            return .dictionary(lhs) == rhs()
-        case (.list(let lhs), .lazy(let rhs)):
-            return .list(lhs) == rhs()
-        case (.string(let lhs), .lazy(let rhs)):
-            return .string(lhs) == rhs()
-        default:
-            return false
-        }
-    }
-}
+extension Logging.Metadata.Value: Equatable {}
 
 /// Ships with the logging module, used to multiplex to multiple logging handlers
 public final class MultiplexLogging {
@@ -316,8 +288,6 @@ extension Logging.Metadata.Value: CustomStringConvertible {
             return list.map { $0.description }.description
         case .string(let str):
             return str
-        case .lazy(let thunk):
-            return thunk().description
         }
     }
 }

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -125,21 +125,6 @@ class LoggingTest: XCTestCase {
                                                    "nested-list": ["l1str", ["l2str1", "l2str2"]]])
     }
 
-    func testLazyMetadata() {
-        let testLogging = TestLogging()
-        Logging.bootstrap(testLogging.make)
-        var logger = Logging.make("\(#function)")
-        logger[metadataKey: "lazy-str"] = .lazy({ "foo" })
-        logger[metadataKey: "lazy-list"] = .lazy({ [.lazy({ "bar" })] })
-        logger[metadataKey: "lazy-dict"] = .lazy({ ["buz": .lazy({ "qux" })] })
-        logger.info("hello world!")
-        testLogging.history.assertExist(level: .info,
-                                        message: "hello world!",
-                                        metadata: ["lazy-str": "foo",
-                                                   "lazy-list": ["bar"],
-                                                   "lazy-dict": ["buz": "qux"]])
-    }
-
     private func dontEvaluateThisString(file: StaticString = #file, line: UInt = #line) -> String {
         XCTFail("should not have been evaluated", file: file, line: line)
         return "should not have been evaluated"
@@ -150,7 +135,6 @@ class LoggingTest: XCTestCase {
         Logging.bootstrap(testLogging.make)
         var logger = Logging.make("\(#function)")
         logger.logLevel = .error
-        logger[metadataKey: "foo"] = .lazy({ "\(self.dontEvaluateThisString())" })
 
         logger.debug(self.dontEvaluateThisString(), metadata: ["foo": "\(self.dontEvaluateThisString())"])
         logger.trace(self.dontEvaluateThisString())


### PR DESCRIPTION
sorry @ktoso , does this make sense?

Motivation:

Two reasons for the removal:

1. I don't see a compelling reason to add lazy metadata to the metadata
   storage. Lazy metadata makes sense if it's passed directly to a log
   method like

       logger.info("foo", metadata: somethingExpensive())

   but I don't think this makes a whole lot of sense

       logger[metadataKey: "foo"] = .lazy({ somethingExpensive() })

   why? It's very likely that it'll get evalutated because any next
   log message that gets logged will force it but it's totally
   unclear which one that'll be.

2. More importantly, the lazy metadata can't be implemented correctly
   because we can't memoize the result of the expensive computation
   because we can only mutate the `LogHandler` in mutating methods and
   the log methods aren't mutating.