### PR TITLE
Allow carrying CustomStringConvertible in metadata #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The logging metadata is of type `typealias Logging.Metadata = [String: Metadata.
 ```swift
 public enum MetadataValue {
     case string(String)
+    case stringConvertible(CustomStringConvertible)
     case dictionary(Metadata)
     case array([Metadata.Value])
 }

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -119,6 +119,7 @@ extension Logging {
 
     public enum MetadataValue {
         case string(String)
+        case stringConvertible(CustomStringConvertible)
         case dictionary(Metadata)
         case array([Metadata.Value])
     }
@@ -146,6 +147,8 @@ extension Logging.MetadataValue: Equatable {
         switch (lhs, rhs) {
         case (.string(let lhs), .string(let rhs)):
             return lhs == rhs
+        case (.stringConvertible(let lhs), .stringConvertible(let rhs)):
+            return lhs.description == rhs.description
         case (.array(let lhs), .array(let rhs)):
             return lhs == rhs
         case (.dictionary(let lhs), .dictionary(let rhs)):
@@ -305,6 +308,8 @@ extension Logging.MetadataValue: CustomStringConvertible {
             return list.map { $0.description }.description
         case .string(let str):
             return str
+        case .stringConvertible(let repr):
+            return repr.description
         }
     }
 }

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -125,6 +125,52 @@ class LoggingTest: XCTestCase {
                                                    "nested-list": ["l1str", ["l2str1", "l2str2"]]])
     }
 
+    // Example of custom "box" which may be used to implement "render at most once" semantics
+    // Not thread-safe, thus should not be shared across threads.
+    internal class LazyMetadataBox: CustomStringConvertible {
+        private var makeValue: (() -> String)?
+        private var _value: String? = nil
+
+        public init(_ makeValue: @escaping () -> String) {
+            self.makeValue = makeValue
+        }
+
+        /// This allows caching a value in case it is accessed via an by name subscript,
+        // rather than as part of rendering all metadata that a LoggingContext was carrying
+        public var value: String {
+            if let f = self.makeValue {
+                self._value = f()
+                self.makeValue = nil
+            }
+
+            assert(self._value != nil, "_value MUST NOT be nil once `lazyValue` has run.")
+            return self._value!
+        }
+
+        var hasRendered: Bool {
+            return value != nil
+        }
+
+        public var description: String {
+            return "\(self.value)"
+        }
+    }
+
+    func testStringConvertibleMetadata() {
+        let testLogging = TestLogging()
+        Logging.bootstrap(testLogging.make)
+        var logger = Logging.make("\(#function)")
+        logger[metadataKey: "foo"] = .stringConvertible("raw-string")
+        let lazyBox = LazyMetadataBox({ "rendered-at-first-use" })
+        logger[metadataKey: "lazy"] = .stringConvertible(lazyBox)
+        logger.info("hello world!")
+        XCTAssertTrue(lazyBox.hasRendered)
+        testLogging.history.assertExist(level: .info,
+                                        message: "hello world!",
+                                        metadata: ["foo": .stringConvertible("raw-string"),
+                                                   "lazy": .stringConvertible(LazyMetadataBox({ "rendered-at-first-use" }))])
+    }
+
     private func dontEvaluateThisString(file: StaticString = #file, line: UInt = #line) -> String {
         XCTFail("should not have been evaluated", file: file, line: line)
         return "should not have been evaluated"


### PR DESCRIPTION
This has numerous benefits, most of which center around values which may
have expensive to perform custom `description` implementations, e.g.
yet are neither a dictionary nor an array.

It also allows carrying and thus "delaying" rendering of string
representations until they are actually needed. E.g. one can imagine
wanting to avoid rendering a string representation of a value if a
logger never would log any of the metadata, esp. if the rendering is a
heavy process.

Resolves https://github.com/weissi/swift-server-logging-api-proposal/issues/24

----

This can be seen as a more refined version of 
https://github.com/weissi/swift-server-logging-api-proposal/pull/18

I have spent significant time exploring alternatives (including implementing the same style of semantics without such type in the library, by doing a proxying log handler with additional storage for example), though the alternatives quickly explode in complexity and are not possible to expose safely to Logger end users without resorting to casts in implementations etc. I can explain the various tradeoffs in depth if need be. All in all, I believe this unlocks the most potential while not impacting the most typical use of metadata which are likely the strict strings.

This also makes it simpler to store any (value, preferably) type which already conforms to `CustomStringConvertible` - as many real world types do - directly inside the metadata container.