### PR TITLE
change example loggers to structs

### DIFF
--- a/Sources/ExampleImplementation/ConfigLogging.swift
+++ b/Sources/ExampleImplementation/ConfigLogging.swift
@@ -8,7 +8,7 @@ import Logging
 // this is a contrived example of a logging library implementation that allows users to define log levels per logger label
 // this example uses a simplistic in-memory config which can be changed at runtime via code
 // real implementations could use external config files that can be changed outside the running program
-public final class ConfigLogging {
+public struct ConfigLogging {
     public var config = Config(defaultLogLevel: .info)
 
     public init() {}

--- a/Sources/ExampleImplementation/FileLogging.swift
+++ b/Sources/ExampleImplementation/FileLogging.swift
@@ -11,7 +11,7 @@ import Logging
 #endif
 
 // this is a contrived example of a logging library implementation that writes logs to files
-public final class FileLogging {
+public struct FileLogging {
     private let defaultLogLevel: Logging.Level = .info
     private let fileHandler = FileHandler()
 

--- a/Sources/ExampleImplementation/SimpleLogger.swift
+++ b/Sources/ExampleImplementation/SimpleLogger.swift
@@ -6,7 +6,7 @@ import Foundation
 import Logging
 
 // helper class to keep things DRY
-internal final class SimpleLogger {
+internal struct SimpleLogger {
     let label: String
     private var _logLevel: Logging.Level?
     private let formatter: DateFormatter

--- a/Sources/ExampleImplementation/SimpleLogging.swift
+++ b/Sources/ExampleImplementation/SimpleLogging.swift
@@ -6,7 +6,7 @@ import Foundation
 import Logging
 
 // this is a contrived example of a logging library implementation that writes logs to stdout
-public final class SimpleLogging {
+public struct SimpleLogging {
     private let defaultLogLevel = Logging.Level.info
 
     public init() {}

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -207,7 +207,7 @@ private class MUXLogHandler: LogHandler {
 }
 
 /// Ships with the logging module, really boring just prints something using the `print` function
-internal final class StdoutLogger: LogHandler {
+internal struct StdoutLogger: LogHandler {
     private let lock = Lock()
 
     public init(label: String) {}


### PR DESCRIPTION
motivation: encourage use of immutable loggers

changes: change example loggers to structs