### PR TITLE
 enforce that logging system can only be bootstrapped once

### DIFF
--- a/Sources/ExampleUsage/ConfigExample.swift
+++ b/Sources/ExampleUsage/ConfigExample.swift
@@ -4,13 +4,14 @@
 
 import ExampleImplementation
 import Foundation
-import Logging
+@testable import Logging // need access to internal bootstrap function
 
 enum ConfigExample {
     static func main() {
         // boostrap with our config based sample implementations
         let config = Config(defaultLogLevel: .info)
-        LoggingSystem.bootstrap({ ConfigLogHandler(label: $0, config: config) })
+        LoggingSystem.bootstrapInternal({ ConfigLogHandler(label: $0, config: config) })
+        
         // run the example
         let logger = Logger(label: "com.example.TestApp")
         logger.trace("hello world?")

--- a/Sources/ExampleUsage/ContextBasedSystem.swift
+++ b/Sources/ExampleUsage/ContextBasedSystem.swift
@@ -2,7 +2,6 @@
 // THIS IS NOT PART OF THE PITCH, JUST AN EXAMPLE HOW A LOGGER USAGE LOOKS LIKE
 //
 
-import ExampleImplementation
 import Foundation
 import Logging
 
@@ -11,8 +10,6 @@ import Logging
 // we also allow users to set metadata on the context object and reuse that as the metadata for logging
 enum ContextBasedSystem {
     static func main() {
-        // boostrap with our sample implementation
-        LoggingSystem.bootstrap(SimpleLogHandler.init)
         // run the example
         for i in 1 ... 2 {
             print("---------------------------- processing request #\(i) ----------------------------")

--- a/Sources/ExampleUsage/GlobalLoggerBasedSystem.swift
+++ b/Sources/ExampleUsage/GlobalLoggerBasedSystem.swift
@@ -2,7 +2,6 @@
 // THIS IS NOT PART OF THE PITCH, JUST AN EXAMPLE HOW A LOGGER USAGE LOOKS LIKE
 //
 
-import ExampleImplementation
 import Foundation
 import Logging
 
@@ -25,8 +24,6 @@ var logger: Logger {
 // this is a contrived example of a system that shares one global logger
 enum GlobalLoggerBasedSystem {
     static func main() {
-        // boostrap with our sample implementation
-        LoggingSystem.bootstrap(SimpleLogHandler.init)
         // run the example
         for i in 1 ... 2 {
             print("---------------------------- processing request #\(i) ----------------------------")

--- a/Sources/ExampleUsage/LocalLoggerBasedSystem.swift
+++ b/Sources/ExampleUsage/LocalLoggerBasedSystem.swift
@@ -2,15 +2,12 @@
 // THIS IS NOT PART OF THE PITCH, JUST AN EXAMPLE HOW A LOGGER USAGE LOOKS LIKE
 //
 
-import ExampleImplementation
 import Foundation
 import Logging
 
 // this is a contrived example of a system where each component obtain its own logger
 enum LocalLoggerBasedSystem {
     static func main() {
-        // boostrap with our sample implementation
-        LoggingSystem.bootstrap(SimpleLogHandler.init)
         // run the example
         for i in 1 ... 2 {
             print("---------------------------- processing request #\(i) ----------------------------")

--- a/Sources/ExampleUsage/MultiplexExample.swift
+++ b/Sources/ExampleUsage/MultiplexExample.swift
@@ -4,12 +4,13 @@
 
 import ExampleImplementation
 import Foundation
-import Logging
+@testable import Logging // need access to internal bootstrap function 
 
 enum MultiplexExample {
     static func main() {
         // boostrap with two of our sample implementations
-        LoggingSystem.bootstrap({ MultiplexLogHandler([SimpleLogHandler(label: $0), FileLogHandler(label: $0)]) })
+        LoggingSystem.bootstrapInternal({ MultiplexLogHandler([SimpleLogHandler(label: $0), FileLogHandler(label: $0)]) })
+
         // run the example
         let logger = Logger(label: "com.example.TestApp")
         logger.info("hello world!")

--- a/Sources/ExampleUsage/main.swift
+++ b/Sources/ExampleUsage/main.swift
@@ -1,3 +1,9 @@
+import Logging
+import ExampleImplementation
+
+// boostrap with our sample implementation
+LoggingSystem.bootstrap(SimpleLogHandler.init)
+
 print()
 print("##### global logger based system #####")
 GlobalLoggerBasedSystem.main()

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -103,10 +103,20 @@ public struct Logger {
 public enum LoggingSystem {
     fileprivate static let lock = ReadWriteLock()
     fileprivate static var factory: (String) -> LogHandler = StdoutLogHandler.init
+    fileprivate static var initialized = false
 
     // Configures which `LogHandler` to use in the application.
     public static func bootstrap(_ factory: @escaping (String) -> LogHandler) {
         lock.withWriterLock {
+            precondition(!self.initialized, "logging system can only be initialized once per process. currently used factory: \(self.factory)")
+            self.factory = factory
+            self.initialized = true
+        }
+    }
+
+    // for our testing we want to allow multiple bootstraping
+    internal static func bootstrapInternal(_ factory: @escaping (String) -> LogHandler) {
+        self.lock.withWriterLock {
             self.factory = factory
         }
     }

--- a/Tests/LoggingTests/GlobalLoggingTest.swift
+++ b/Tests/LoggingTests/GlobalLoggingTest.swift
@@ -5,7 +5,8 @@ class GlobalLoggerTest: XCTestCase {
     func test1() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrap(logging.make)
+        LoggingSystem.bootstrapInternal(logging.make)
+
         // change test logging config to log traces and above
         logging.config.set(value: Logger.Level.trace)
         // run our program
@@ -31,7 +32,8 @@ class GlobalLoggerTest: XCTestCase {
     func test2() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrap(logging.make)
+        LoggingSystem.bootstrapInternal(logging.make)
+
         // change test logging config to log errors and above
         logging.config.set(value: Logger.Level.error)
         // run our program
@@ -57,7 +59,8 @@ class GlobalLoggerTest: XCTestCase {
     func test3() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrap(logging.make)
+        LoggingSystem.bootstrapInternal(logging.make)
+
         // change test logging config
         logging.config.set(value: .warning)
         logging.config.set(key: "GlobalLoggerTest::Struct2", value: .info)

--- a/Tests/LoggingTests/LocalLoggingTest.swift
+++ b/Tests/LoggingTests/LocalLoggingTest.swift
@@ -5,7 +5,8 @@ class LocalLoggerTest: XCTestCase {
     func test1() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrap(logging.make)
+        LoggingSystem.bootstrapInternal(logging.make)
+
         // change test logging config to log traces and above
         logging.config.set(value: Logger.Level.trace)
         // run our program
@@ -32,7 +33,8 @@ class LocalLoggerTest: XCTestCase {
     func test2() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrap(logging.make)
+        LoggingSystem.bootstrapInternal(logging.make)
+
         // change test logging config to log errors and above
         logging.config.set(value: Logger.Level.error)
         // run our program

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -5,7 +5,8 @@ class LoggingTest: XCTestCase {
     func testAutoclosure() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrap(logging.make)
+        LoggingSystem.bootstrapInternal(logging.make)
+        
         var logger = Logger(label: "test")
         logger.logLevel = .info
         logger.log(level: .trace, {
@@ -41,7 +42,7 @@ class LoggingTest: XCTestCase {
         // bootstrap with our test logging impl
         let logging1 = TestLogging()
         let logging2 = TestLogging()
-        LoggingSystem.bootstrap({ MultiplexLogHandler([logging1.make(label: $0), logging2.make(label: $0)]) })
+        LoggingSystem.bootstrapInternal({ MultiplexLogHandler([logging1.make(label: $0), logging2.make(label: $0)]) })
 
         var logger = Logger(label: "test")
         logger.logLevel = .warning
@@ -60,7 +61,8 @@ class LoggingTest: XCTestCase {
 
     func testDictionaryMetadata() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrap(testLogging.make)
+        LoggingSystem.bootstrapInternal(testLogging.make)
+        
         var logger = Logger(label: "\(#function)")
         logger[metadataKey: "foo"] = ["bar": "buz"]
         logger[metadataKey: "empty-dict"] = [:]
@@ -75,7 +77,8 @@ class LoggingTest: XCTestCase {
 
     func testListMetadata() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrap(testLogging.make)
+        LoggingSystem.bootstrapInternal(testLogging.make)
+        
         var logger = Logger(label: "\(#function)")
         logger[metadataKey: "foo"] = ["bar", "buz"]
         logger[metadataKey: "empty-list"] = []
@@ -121,8 +124,9 @@ class LoggingTest: XCTestCase {
 
     func testStringConvertibleMetadata() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrap(testLogging.make)
+        LoggingSystem.bootstrapInternal(testLogging.make)
         var logger = Logger(label: "\(#function)")
+
         logger[metadataKey: "foo"] = .stringConvertible("raw-string")
         let lazyBox = LazyMetadataBox({ "rendered-at-first-use" })
         logger[metadataKey: "lazy"] = .stringConvertible(lazyBox)
@@ -141,7 +145,8 @@ class LoggingTest: XCTestCase {
 
     func testAutoClosuresAreNotForcedUnlessNeeded() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrap(testLogging.make)
+        LoggingSystem.bootstrapInternal(testLogging.make)
+
         var logger = Logger(label: "\(#function)")
         logger.logLevel = .error
 
@@ -154,7 +159,8 @@ class LoggingTest: XCTestCase {
 
     func testLocalMetadata() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrap(testLogging.make)
+        LoggingSystem.bootstrapInternal(testLogging.make)
+
         var logger = Logger(label: "\(#function)")
         logger.info("hello world!", metadata: ["foo": "bar"])
         logger[metadataKey: "bar"] = "baz"

--- a/Tests/LoggingTests/MDCTest.swift
+++ b/Tests/LoggingTests/MDCTest.swift
@@ -6,7 +6,8 @@ class MDCTest: XCTestCase {
     func test1() throws {
         // bootstrap with our test logger
         let logging = TestLogging()
-        LoggingSystem.bootstrap(logging.make)
+        LoggingSystem.bootstrapInternal(logging.make)
+
         // run the program
         MDC.global["foo"] = "bar"
         let group = DispatchGroup()


### PR DESCRIPTION
motivation: safer logging system

changes: do a precondition check to verify logging syste is only initialized/bootstrapped once per process