### PR TITLE
remove error argument from logging API

### DIFF
--- a/Sources/ExampleImplementation/CommonLogHandler.swift
+++ b/Sources/ExampleImplementation/CommonLogHandler.swift
@@ -21,9 +21,9 @@ internal struct CommonLogHandler {
         self.formatter = formatter
     }
 
-    public func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, error: Error?, printer: (String) -> Void) {
+    public func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, printer: (String) -> Void) {
         let prettyMetadata = metadata?.isEmpty ?? true ? self.prettyMetadata : self.prettify(self.metadata.merging(metadata!, uniquingKeysWith: { _, new in new }))
-        printer("[\(self.label)] \(self.formatter.string(from: Date()))\(prettyMetadata.map { " \($0)" } ?? "") \(level): \(message)\(error.map { " \($0)" } ?? "")")
+        printer("[\(self.label)] \(self.formatter.string(from: Date()))\(prettyMetadata.map { " \($0)" } ?? "") \(level): \(message)")
     }
 
     public var logLevel: Logger.Level? {

--- a/Sources/ExampleImplementation/ConfigLogHandler.swift
+++ b/Sources/ExampleImplementation/ConfigLogHandler.swift
@@ -49,8 +49,8 @@ public struct ConfigLogHandler: LogHandler {
         self.config = config
     }
 
-    public func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, error: Error?, file: StaticString, function: StaticString, line: UInt) {
-        self.handler.log(level: level, message: message, metadata: metadata, error: error) { text in
+    public func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, file: StaticString, function: StaticString, line: UInt) {
+        self.handler.log(level: level, message: message, metadata: metadata) { text in
             print(text)
         }
     }

--- a/Sources/ExampleImplementation/FileLogHandler.swift
+++ b/Sources/ExampleImplementation/FileLogHandler.swift
@@ -25,8 +25,8 @@ public struct FileLogHandler: LogHandler {
         self.defaultLogLevel = defaultLogLevel
     }
 
-    public func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, error: Error?, file: StaticString, function: StaticString, line: UInt) {
-        self.handler.log(level: level, message: message, metadata: metadata, error: error) { text in
+    public func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, file: StaticString, function: StaticString, line: UInt) {
+        self.handler.log(level: level, message: message, metadata: metadata) { text in
             self.fileHandler._write(text)
         }
     }

--- a/Sources/ExampleImplementation/SimpleLogHandler.swift
+++ b/Sources/ExampleImplementation/SimpleLogHandler.swift
@@ -19,8 +19,8 @@ public struct SimpleLogHandler: LogHandler {
         self.defaultLogLevel = defaultLogLevel
     }
 
-    public func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, error: Error?, file: StaticString, function: StaticString, line: UInt) {
-        self.handler.log(level: level, message: message, metadata: metadata, error: error) { text in
+    public func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, file: StaticString, function: StaticString, line: UInt) {
+        self.handler.log(level: level, message: message, metadata: metadata) { text in
             print(text)
         }
     }

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -10,7 +10,7 @@ public protocol LogHandler {
     // `Logger`'s `info`, `error`, or `warning` functions.
     //
     // An implementation does not need to check the log level because that has been done before by `Logger` itself.
-    func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, error: Error?, file: StaticString, function: StaticString, line: UInt)
+    func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, file: StaticString, function: StaticString, line: UInt)
 
     // This adds metadata to a place the concrete logger considers appropriate. Some loggers
     // might not support this feature at all.
@@ -36,35 +36,35 @@ public struct Logger {
     }
 
     @inlinable
-    public func log(level: Logger.Level, _ message: @autoclosure () -> String, metadata: @autoclosure () -> Logger.Metadata? = nil, error: Error? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
+    public func log(level: Logger.Level, _ message: @autoclosure () -> String, metadata: @autoclosure () -> Logger.Metadata? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
         if self.logLevel <= level {
-            self.handler.log(level: level, message: message(), metadata: metadata(), error: error, file: file, function: function, line: line)
+            self.handler.log(level: level, message: message(), metadata: metadata(), file: file, function: function, line: line)
         }
     }
 
     @inlinable
-    public func trace(_ message: @autoclosure () -> String, metadata: @autoclosure () -> Logger.Metadata? = nil, error: Error? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
-        self.log(level: .trace, message, metadata: metadata, error: error, file: file, function: function, line: line)
+    public func trace(_ message: @autoclosure () -> String, metadata: @autoclosure () -> Logger.Metadata? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
+        self.log(level: .trace, message, metadata: metadata, file: file, function: function, line: line)
     }
 
     @inlinable
-    public func debug(_ message: @autoclosure () -> String, metadata: @autoclosure () -> Logger.Metadata? = nil, error: Error? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
-        self.log(level: .debug, message, metadata: metadata, error: error, file: file, function: function, line: line)
+    public func debug(_ message: @autoclosure () -> String, metadata: @autoclosure () -> Logger.Metadata? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
+        self.log(level: .debug, message, metadata: metadata, file: file, function: function, line: line)
     }
 
     @inlinable
-    public func info(_ message: @autoclosure () -> String, metadata: @autoclosure () -> Logger.Metadata? = nil, error: Error? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
-        self.log(level: .info, message, metadata: metadata, error: error, file: file, function: function, line: line)
+    public func info(_ message: @autoclosure () -> String, metadata: @autoclosure () -> Logger.Metadata? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
+        self.log(level: .info, message, metadata: metadata, file: file, function: function, line: line)
     }
 
     @inlinable
-    public func warning(_ message: @autoclosure () -> String, metadata: @autoclosure () -> Logger.Metadata? = nil, error: Error? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
-        self.log(level: .warning, message, metadata: metadata, error: error, file: file, function: function, line: line)
+    public func warning(_ message: @autoclosure () -> String, metadata: @autoclosure () -> Logger.Metadata? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
+        self.log(level: .warning, message, metadata: metadata, file: file, function: function, line: line)
     }
 
     @inlinable
-    public func error(_ message: @autoclosure () -> String, metadata: @autoclosure () -> Logger.Metadata? = nil, error: Error? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
-        self.log(level: .error, message, metadata: metadata, error: error, file: file, function: function, line: line)
+    public func error(_ message: @autoclosure () -> String, metadata: @autoclosure () -> Logger.Metadata? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
+        self.log(level: .error, message, metadata: metadata, file: file, function: function, line: line)
     }
 
     @inlinable
@@ -186,9 +186,9 @@ public class MultiplexLogHandler: LogHandler {
         }
     }
 
-    public func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, error: Error?, file: StaticString, function: StaticString, line: UInt) {
+    public func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, file: StaticString, function: StaticString, line: UInt) {
         self.handlers.forEach { handler in
-            handler.log(level: level, message: message, metadata: metadata, error: error, file: file, function: function, line: line)
+            handler.log(level: level, message: message, metadata: metadata, file: file, function: function, line: line)
         }
     }
 
@@ -246,9 +246,9 @@ internal struct StdoutLogHandler: LogHandler {
         }
     }
 
-    public func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, error: Error?, file: StaticString, function: StaticString, line: UInt) {
+    public func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, file: StaticString, function: StaticString, line: UInt) {
         let prettyMetadata = metadata?.isEmpty ?? true ? self.prettyMetadata : self.prettify(self.metadata.merging(metadata!, uniquingKeysWith: { _, new in new }))
-        print("\(self.timestamp()) \(level)\(prettyMetadata.map { " \($0)" } ?? "") \(message)\(error.map { " \($0)" } ?? "")")
+        print("\(self.timestamp()) \(level)\(prettyMetadata.map { " \($0)" } ?? "") \(message)")
     }
 
     public var metadata: Logger.Metadata {

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -37,47 +37,6 @@ class LoggingTest: XCTestCase {
         logging.history.assertExist(level: .error, message: "error")
     }
 
-    func testAutoclosureWithError() throws {
-        // bootstrap with our test logging impl
-        let logging = TestLogging()
-        LoggingSystem.bootstrap(logging.make)
-        var logger = Logger(label: "test")
-        logger.logLevel = .warning
-        logger.trace({
-            XCTFail("trace should not be called")
-            return "trace"
-        }(), error: TestError.boom)
-        logger.debug({
-            XCTFail("debug should not be called")
-            return "debug"
-        }(), error: TestError.boom)
-        logger.info({
-            XCTFail("info should not be called")
-            return "info"
-        }(), error: TestError.boom)
-        logger.warning({
-            "warning"
-        }(), error: TestError.boom)
-        logger.error({
-            "error"
-        }(), error: TestError.boom)
-        XCTAssertEqual(2, logging.history.entries.count, "expected number of entries to match")
-        logging.history.assertNotExist(level: .trace, message: "trace", error: TestError.boom)
-        logging.history.assertNotExist(level: .debug, message: "debug", error: TestError.boom)
-        logging.history.assertNotExist(level: .info, message: "info", error: TestError.boom)
-        logging.history.assertExist(level: .warning, message: "warning", error: TestError.boom)
-        logging.history.assertExist(level: .error, message: "error", error: TestError.boom)
-    }
-
-    func testWithError() throws {
-        let logging = TestLogging()
-        LoggingSystem.bootstrap(logging.make)
-
-        let logger = Logger(label: "test")
-        logger.error("oh no!", error: TestError.boom)
-        logging.history.assertExist(level: .error, message: "oh no!", error: TestError.boom)
-    }
-
     func testMultiplex() throws {
         // bootstrap with our test logging impl
         let logging1 = TestLogging()
@@ -209,7 +168,7 @@ class LoggingTest: XCTestCase {
 
     func testCustomFactory() {
         struct CustomHandler: LogHandler {
-            func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, error: Error?, file: StaticString, function: StaticString, line: UInt) {}
+            func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, file: StaticString, function: StaticString, line: UInt) {}
 
             subscript(metadataKey _: String) -> Logger.Metadata.Value? {
                 get { return nil }

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -30,12 +30,12 @@ internal struct TestLogHandler: LogHandler {
         self.logger.logLevel = .trace
     }
 
-    func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, error: Error?, file: StaticString, function: StaticString, line: UInt) {
+    func log(level: Logger.Level, message: String, metadata: Logger.Metadata?, file: StaticString, function: StaticString, line: UInt) {
         let metadata = (self._metadataSet ? self.metadata : MDC.global.metadata).merging(metadata ?? [:], uniquingKeysWith: { _, new in new })
         var l = logger // local copy since we gonna override its metadata
         l.metadata = metadata
-        l.log(level: level, message, metadata: metadata, error: error, file: file, function: function, line: line)
-        self.recorder.record(level: level, metadata: metadata, message: message, error: error)
+        l.log(level: level, message, metadata: metadata, file: file, function: function, line: line)
+        self.recorder.record(level: level, metadata: metadata, message: message)
     }
 
     private var _logLevel: Logger.Level?
@@ -112,9 +112,9 @@ internal class Recorder: History {
     private let lock = NSLock()
     private var _entries = [LogEntry]()
 
-    func record(level: Logger.Level, metadata: Logger.Metadata?, message: String, error: Error?) {
+    func record(level: Logger.Level, metadata: Logger.Metadata?, message: String) {
         return self.lock.withLock {
-            self._entries.append(LogEntry(level: level, metadata: metadata, message: message, error: error))
+            self._entries.append(LogEntry(level: level, metadata: metadata, message: message))
         }
     }
 
@@ -159,26 +159,24 @@ internal struct LogEntry {
     let level: Logger.Level
     let metadata: Logger.Metadata?
     let message: String
-    let error: Error?
 }
 
 extension History {
-    func assertExist(level: Logger.Level, message: String, metadata: Logger.Metadata? = nil, error: Error? = nil, file: StaticString = #file, line: UInt = #line) {
-        let entry = self.find(level: level, message: message, metadata: metadata, error: error)
-        XCTAssertNotNil(entry, "entry not found: \(level), \(String(describing: metadata)), \(message) \(String(describing: error))", file: file, line: line)
+    func assertExist(level: Logger.Level, message: String, metadata: Logger.Metadata? = nil, file: StaticString = #file, line: UInt = #line) {
+        let entry = self.find(level: level, message: message, metadata: metadata)
+        XCTAssertNotNil(entry, "entry not found: \(level), \(String(describing: metadata)), \(message) ", file: file, line: line)
     }
 
-    func assertNotExist(level: Logger.Level, message: String, metadata: Logger.Metadata? = nil, error: Error? = nil, file: StaticString = #file, line: UInt = #line) {
-        let entry = self.find(level: level, message: message, metadata: metadata, error: error)
-        XCTAssertNil(entry, "entry was found: \(level), \(String(describing: metadata)), \(message) \(String(describing: error))", file: file, line: line)
+    func assertNotExist(level: Logger.Level, message: String, metadata: Logger.Metadata? = nil, file: StaticString = #file, line: UInt = #line) {
+        let entry = self.find(level: level, message: message, metadata: metadata)
+        XCTAssertNil(entry, "entry was found: \(level), \(String(describing: metadata)), \(message)", file: file, line: line)
     }
 
-    func find(level: Logger.Level, message: String, metadata: Logger.Metadata? = nil, error: Error?) -> LogEntry? {
+    func find(level: Logger.Level, message: String, metadata: Logger.Metadata? = nil) -> LogEntry? {
         return self.entries.first { entry in
             entry.level == level &&
                 entry.message == message &&
-                entry.metadata ?? [:] == metadata ?? [:] &&
-                entry.error?.localizedDescription ?? "" == error?.localizedDescription ?? ""
+                entry.metadata ?? [:] == metadata ?? [:]
         }
     }
 }


### PR DESCRIPTION
motivation: since Error in swift does not carry any additional information (such as stack traces) that can be useful in formatting decision the LogHandler may need to do, there is no real reason to treat it as special in the API, and it can just be "strigified" at the calling site

changes: remove error params from all APIs