### PR TITLE
string interpolation backward compat fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /Packages
 /*.xcodeproj
 .xcode
+DerivedData
+

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -313,15 +313,21 @@ extension Logging.MetadataValue: CustomStringConvertible {
 
 // Extension has to be done on explicit type rather than Logging.Metadata.Value as workaround for: https://bugs.swift.org/browse/SR-9687
 extension Logging.MetadataValue: ExpressibleByStringInterpolation {
-    #if !swift(>=5.0)
-        public init(stringInterpolation strings: Logging.Metadata.Value...) {
-            self = .string(strings.map { $0.description }.reduce("", +))
-        }
+    public typealias StringInterpolation = Logging.MetadataValue
+    
+    public init(stringInterpolation: Logging.MetadataValue) {
+        self = stringInterpolation
+    }
+}
 
-        public init<T>(stringInterpolationSegment expr: T) {
-            self = .string(String(stringInterpolationSegment: expr))
-        }    
-    #endif
+extension Logging.MetadataValue: StringInterpolationProtocol {
+    public init(literalCapacity: Int, interpolationCount: Int) {
+        self = .string("")
+    }
+    
+    public mutating func appendLiteral(_ literal: String) {
+        self = .string(self.description + literal)
+    }
 }
 
 // Extension has to be done on explicit type rather than Logging.Metadata.Value as workaround for: https://bugs.swift.org/browse/SR-9687

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -313,21 +313,15 @@ extension Logging.MetadataValue: CustomStringConvertible {
 
 // Extension has to be done on explicit type rather than Logging.Metadata.Value as workaround for: https://bugs.swift.org/browse/SR-9687
 extension Logging.MetadataValue: ExpressibleByStringInterpolation {
-    public typealias StringInterpolation = Logging.MetadataValue
-    
-    public init(stringInterpolation: Logging.MetadataValue) {
-        self = stringInterpolation
-    }
-}
+    #if !compiler(>=5.0)
+        public init(stringInterpolation strings: Logging.Metadata.Value...) {
+            self = .string(strings.map { $0.description }.reduce("", +))
+        }
 
-extension Logging.MetadataValue: StringInterpolationProtocol {
-    public init(literalCapacity: Int, interpolationCount: Int) {
-        self = .string("")
-    }
-    
-    public mutating func appendLiteral(_ literal: String) {
-        self = .string(self.description + literal)
-    }
+        public init<T>(stringInterpolationSegment expr: T) {
+            self = .string(String(stringInterpolationSegment: expr))
+        }    
+    #endif
 }
 
 // Extension has to be done on explicit type rather than Logging.Metadata.Value as workaround for: https://bugs.swift.org/browse/SR-9687


### PR DESCRIPTION
This fixes:

```
/root/project/.build/checkouts/swift-server-logging-api-proposal/Sources/Logging/Logging.swift:317:16: warning: initializer 'init(stringInterpolation:)' nearly matches defaulted requirement 'init(stringInterpolation:)' of protocol 'ExpressibleByStringInterpolation'
        public init(stringInterpolation strings: Logging.Metadata.Value...) {
               ^
/root/project/.build/checkouts/swift-server-logging-api-proposal/Sources/Logging/Logging.swift:317:16: note: candidate has non-matching type '(stringInterpolation: Logging.Metadata.Value...)' (aka '(stringInterpolation: Logging.MetadataValue...)') [with StringInterpolation = DefaultStringInterpolation]
        public init(stringInterpolation strings: Logging.Metadata.Value...) {
               ^
/root/project/.build/checkouts/swift-server-logging-api-proposal/Sources/Logging/Logging.swift:317:16: note: move 'init(stringInterpolation:)' to another extension to silence this warning
        public init(stringInterpolation strings: Logging.Metadata.Value...) {
               ^
Swift.ExpressibleByStringInterpolation:3:5: note: requirement 'init(stringInterpolation:)' declared here
    init(stringInterpolation: Self.StringInterpolation)
    ^
/root/project/.build/checkouts/swift-server-logging-api-proposal/Sources/Logging/Logging.swift:322:28: error: argument labels '(stringInterpolationSegment:)' do not match any available overloads
            self = .string(String(stringInterpolationSegment: expr))
                           ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/root/project/.build/checkouts/swift-server-logging-api-proposal/Sources/Logging/Logging.swift:322:28: note: overloads for 'String' exist with these partially matching parameter lists: (Character), (from: Decoder), (cString: UnsafePointer<CChar>), (cString: UnsafePointer<UInt8>), (validatingUTF8: UnsafePointer<CChar>), (_builtinUnicodeScalarLiteral: Int32), (Unicode.Scalar), (stringLiteral: String), (T), (stringInterpolation: DefaultStringInterpolation), (T, radix: Int, uppercase: Bool), (S), (String.UnicodeScalarView), (String.UTF16View), (String.UTF8View), (__shared Substring), (Substring.UTF8View), (Substring.UTF16View), (Substring.UnicodeScalarView), (describing: Subject), (reflecting: Subject)
            self = .string(String(stringInterpolationSegment: expr))
                           ^

Exited with code 1
```

By using the `#compiler` directive instead of `#swift`