### PR TITLE
Add missing label in tests

### DIFF
--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -140,7 +140,7 @@ class LoggingTest: XCTestCase {
         logger.trace(self.dontEvaluateThisString())
         logger.info(self.dontEvaluateThisString())
         logger.warning(self.dontEvaluateThisString())
-        logger.log(level: .warning, self.dontEvaluateThisString())
+        logger.log(level: .warning, message: self.dontEvaluateThisString())
     }
 
     func testLocalMetadata() {


### PR DESCRIPTION
The plain log method requires the `message:` label.