### PR TITLE
Write newline after writing String in file logger

### DIFF
--- a/Sources/ExampleImplementation/FileLogHandler.swift
+++ b/Sources/ExampleImplementation/FileLogHandler.swift
@@ -65,6 +65,6 @@ private class FileHandler {
     }
 
     func _write(_ text: String) {
-        write(self.fd, text, text.utf8.count)
+        write(self.fd, text + "\n", text.utf8.count + 1)
     }
 }


### PR DESCRIPTION
The sample file logger was just appending every String to the file without adding newlines.

This is just a simple demo, a real implementation would most likely use [writev](https://www.tutorialspoint.com/unix_system_calls/writev.htm) (quote @weissi)