### PR TITLE
Add label to LogHandler

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -28,8 +28,10 @@ public protocol LogHandler {
 public struct Logger {
     @usableFromInline
     var handler: LogHandler
+    public let label: String
 
-    internal init(_ handler: LogHandler) {
+    internal init(label: String, _ handler: LogHandler) {
+        self.label = label
         self.handler = handler
     }
 
@@ -129,13 +131,13 @@ extension Logger {
     }
 
     public init(label: String) {
-        self = LoggingSystem.lock.withReaderLock { Logger(LoggingSystem.factory(label)) }
+        self = LoggingSystem.lock.withReaderLock { Logger(label: label, LoggingSystem.factory(label)) }
     }
     
     // this is to provide an escape hatch for situations one must use a custom factory instead of the gloabl one
     // we do not expect this API to be used in normal circumstances, so if you find yourself using it make sure its for a good reason
     public init(label: String, factory: (String) -> LogHandler) {
-        self = Logger(factory(label))
+        self = Logger(label: label, factory(label))
     }
 }
 

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -26,7 +26,7 @@ internal struct TestLogHandler: LogHandler {
         self.label = label
         self.config = config
         self.recorder = recorder
-        self.logger = Logger(StdoutLogHandler(label: label))
+        self.logger = Logger(label: "test", StdoutLogHandler(label: label))
         self.logger.logLevel = .trace
     }
 


### PR DESCRIPTION
Similar to `DispatchQueue` this adds a label property on `LogHandler`. I am not sure though if it makes more sense in the context of logging to make this property non-optional.