### PR TITLE
Add mail mappings for ktoso@apple.com

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,3 +3,4 @@ Tomer Doron <tomerd@apple.com>
 Tomer Doron <tomerd@apple.com> tomer doron <tomer@apple.com>
 Johannes Weiss <johannesweiss@apple.com> <johannes@jweiss.io>
 Max Moiseev <moiseev@apple.com> <moiseev@users.noreply.github.com>
+Konrad `ktoso` Malawski <ktoso@apple.com> <konrad.malawski@project13.pl>

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -15,7 +15,7 @@ needs to be listed here.
 - Iain Smith <iainsmith@users.noreply.github.com>
 - Ian Partridge <i.partridge@uk.ibm.com>
 - Johannes Weiss <johannesweiss@apple.com>
-- Konrad `ktoso` Malawski <konrad.malawski@project13.pl>
+- Konrad `ktoso` Malawski <ktoso@apple.com>
 - Max Moiseev <moiseev@apple.com>
 - Tanner <me@tanner.xyz>
 - Thomas Krajacic <tkrajacic@users.noreply.github.com>


### PR DESCRIPTION
This complements https://github.com/weissi/swift-server-logging-api-proposal/pull/48 with my proper email mappings.